### PR TITLE
ECS will now dynamically allocate ports to containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,4 @@ services:
   web:
     image: nginx:latest
     ports:
-      - "80:80"
+      - "80"

--- a/modules/ec2_instances/main.tf
+++ b/modules/ec2_instances/main.tf
@@ -21,10 +21,10 @@ resource "aws_security_group" "instance" {
     security_groups = ["${var.jump_ssh_sg_id}"]
   }
 
-  # Datacube
+  # ECS dynamically assigns ports in the ephemeral range
   ingress {
-    from_port       = "${var.container_port}"
-    to_port         = "${var.container_port}"
+    from_port       = 32768
+    to_port         = 65535
     protocol        = "TCP"
     security_groups = ["${var.alb_security_group_id}"]
   }


### PR DESCRIPTION
By leaving out the host port in the docker-compose we let docker dynamically allocate a port for the container. The existing Application Load Balancer is clever enough to find this port by using the target group. We also have to open all the ephemeral ports from the cluster to the load balancer as they will now be dynamically assigned.

This allows us to have several of the same container running on a single host as the port is no longer blocked.