### PR TITLE
Enable s3 endpoint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,7 @@ module "vpc" {
   # Use nat instances instead
   enable_nat_gateway           = false
   create_database_subnet_group = true
+  enable_s3_endpoint           = true
 
   tags = {
     workspace  = "${var.workspace}"


### PR DESCRIPTION
The s3 endpoint means our servers don't have to go out of the VPC to talk to S3 (increasing performance and security)