### PR TITLE
Increase Container max mem size

### DIFF
--- a/modules/ec2_instances/variables.tf
+++ b/modules/ec2_instances/variables.tf
@@ -116,7 +116,7 @@ variable "max_container_cpu" {
 }
 
 variable "max_container_mem" {
-  default     = 768
+  default     = 2048
   description = "Largest memory requirements of any task"
 }
 


### PR DESCRIPTION
We are running 2048 mem containers in both dev and production, this change ensures that the cluster auto scales appropriately. 