### PR TITLE
Set dns zone and ssl cert region in parameter store

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,18 @@ This repository contains the Terraform modules for creating a production ready E
 * ecs-cli > 1.0.0 (bda91d5)
 
 ## Running this template
-
+* Configure Dependencies
+  * As this cluster is used to host webservices, you will need a route53 hosted zone
+  * You will also need an Amazon Certificate Manager issued wildcard certificate for the hosted zone. 
 * In order to use the jumpbox in this repo you will require a Jumpbox AMI in your amazon region
   * The jumpbox AMI is identified through ownership by the same account tagged with:
     * "application" = "Jumpbox"
     * "version" = "{{workspace}}" (dev/test/prod)
-  * Setting environment variables to be injected into the script
-    * ```TF_VAR_ssh_ip_address``` will restrict ssh access to the jumpbox to this ip address if the jumpbox is enabled
-    * ```TF_db_admin_username``` will set the admin username of the rds to this variable
-    * ```TF_db_admin_password``` will set the admin password of the rds to this variable
+* Setting environment variables to be injected into the script
+  * ```TF_VAR_ssh_ip_address``` will restrict ssh access to the jumpbox to this ip address if the jumpbox is enabled
+  * ```TF_db_admin_username``` will set the admin username of the rds to this variable
+  * ```TF_db_admin_password``` will set the admin password of the rds to this variable
+
 
 
 ## What is ECS

--- a/_variables.tf
+++ b/_variables.tf
@@ -30,6 +30,19 @@ variable "availability_zones" {
   type        = "list"
 }
 
+# ==================
+# DNS and HTTPS
+
+variable "dns_zone" {
+  default     = ""
+  description = "DNS zone of the service, you will also need a wildcard cert for this domain"
+}
+
+variable "ssl_cert_region" {
+  default     = "ap-southeast-2"
+  description = "The region the certificates exist in"
+}
+
 #--------------------------------------------------------------
 # EC2 Configuration
 #--------------------------------------------------------------

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,4 +5,5 @@ rm -rf .terraform
 export WORKSPACE=$1
 terraform init -backend-config workspaces/$WORKSPACE/backend.cfg
 terraform workspace new $WORKSPACE || terraform workspace select $WORKSPACE
+terraform plan -input=false -var-file="workspaces/$WORKSPACE/terraform.tfvars"
 terraform apply -auto-approve -input=false -var-file="workspaces/$WORKSPACE/terraform.tfvars"

--- a/ssm-parameters.tf
+++ b/ssm-parameters.tf
@@ -1,0 +1,19 @@
+# Write cluster level variables to parameter store, so tasks can query them
+
+data "aws_kms_alias" "ssm" {
+  name = "alias/parameter_store_key"
+}
+
+resource "aws_ssm_parameter" "dns_zone" {
+  name      = "${var.cluster}.dns_zone"
+  value     = "${var.dns_zone}"
+  type      = "String"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "ssl_cert_region" {
+  name      = "${var.cluster}.ssl_cert_region"
+  value     = "${var.ssl_cert_region}"
+  type      = "String"
+  overwrite = true
+}

--- a/workspaces/datacube-dev/terraform.tfvars
+++ b/workspaces/datacube-dev/terraform.tfvars
@@ -27,3 +27,7 @@ enable_jumpbox = true
 key_name = "datacube-dev"
 
 db_multi_az = false
+
+dns_zone = "wms.gadevs.ga"
+
+ssl_cert_region = "ap-southeast-2"

--- a/workspaces/datacube-prod/terraform.tfvars
+++ b/workspaces/datacube-prod/terraform.tfvars
@@ -27,3 +27,7 @@ enable_jumpbox = true
 key_name = "datacube-ecs-dea"
 
 db_multi_az = true
+
+dns_zone = "dea.ga.gov.au"
+
+ssl_cert_region = "ap-southeast-2"


### PR DESCRIPTION
Move cluster dns settings to a parameter 
This enables us to run the same task on dev / prod and just pull the cluster specific config on build.