### PR TITLE
S3 state bucket in param store and asg fix

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -2,6 +2,10 @@ variable "aws_region" {
   default = "ap-southeast-2"
 }
 
+variable "state_bucket" {
+  description = "The s3 bucket used to store terraform state"
+}
+
 #--------------------------------------------------------------
 # Networking
 #--------------------------------------------------------------

--- a/modules/ec2_instances/main.tf
+++ b/modules/ec2_instances/main.tf
@@ -160,6 +160,9 @@ resource "aws_autoscaling_group" "asg" {
 
   lifecycle {
     create_before_destroy = true
+
+    # Our lambda will adjust this automatically
+    ignore_changes = ["desired_capacity"]
   }
 }
 

--- a/ssm-parameters.tf
+++ b/ssm-parameters.tf
@@ -17,3 +17,10 @@ resource "aws_ssm_parameter" "ssl_cert_region" {
   type      = "String"
   overwrite = true
 }
+
+resource "aws_ssm_parameter" "state_bucket" {
+  name      = "${var.cluster}.state_bucket"
+  value     = "${var.state_bucket}"
+  type      = "String"
+  overwrite = true
+}

--- a/workspaces/datacube-dev/terraform.tfvars
+++ b/workspaces/datacube-dev/terraform.tfvars
@@ -2,6 +2,8 @@ vpc_cidr = "10.0.0.0/16"
 
 cluster = "datacube-dev"
 
+state_bucket = "ga-aws-dea-dev-tfstate"
+
 workspace = "datacube-dev"
 
 public_subnet_cidrs = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]

--- a/workspaces/datacube-prod/terraform.tfvars
+++ b/workspaces/datacube-prod/terraform.tfvars
@@ -2,6 +2,8 @@ vpc_cidr = "10.0.0.0/16"
 
 cluster = "datacube-prod"
 
+state_bucket = "dea-devs-tfstate"
+
 workspace = "datacube-prod"
 
 public_subnet_cidrs = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]


### PR DESCRIPTION
- Add state bucket name to param store, this will be used in ecs tasks that need to store state
- Fix a bug in the ASG that scaled it to the default desired level after each deploy.