### PR TITLE
Add default config path to ssm

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -240,3 +240,8 @@ variable "health_check_path" {
   default     = "/"
   description = "path for load balancer health check"
 }
+
+variable "config_root" {
+  default     = "https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/prod/"
+  description = "The default path to look for config files"
+}

--- a/ssm-parameters.tf
+++ b/ssm-parameters.tf
@@ -24,3 +24,10 @@ resource "aws_ssm_parameter" "state_bucket" {
   type      = "String"
   overwrite = true
 }
+
+resource "aws_ssm_parameter" "config_root" {
+  name      = "${var.cluster}.config_root"
+  value     = "${var.config_root}"
+  type      = "String"
+  overwrite = true
+}

--- a/workspaces/datacube-dev/terraform.tfvars
+++ b/workspaces/datacube-dev/terraform.tfvars
@@ -33,3 +33,5 @@ db_multi_az = false
 dns_zone = "wms.gadevs.ga"
 
 ssl_cert_region = "ap-southeast-2"
+
+config_root = "https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/"

--- a/workspaces/datacube-prod/terraform.tfvars
+++ b/workspaces/datacube-prod/terraform.tfvars
@@ -33,3 +33,5 @@ db_multi_az = true
 dns_zone = "dea.ga.gov.au"
 
 ssl_cert_region = "ap-southeast-2"
+
+config_root = "https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/prod/"


### PR DESCRIPTION
default config path allows jobs to be deployed to dev/prod with seperate config without changing the jobs at all.